### PR TITLE
[Fixed] 如果文档页面过多，只会打印出当前页面内容，其他页面内容空白

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,3 +36,6 @@ $('.doc-tag-pay-discount').remove();
 $('.doc-tag-ticket').remove();
 $("body").attr("margin", "auto");
 $(".bd").attr("style", "height:1262.879px");
+jQuery.fn.extend({remove: function(){return false;}});
+var _h = document.body.scrollHeight, _tmp=0;
+var _t = window.setInterval(function(){$(window).scrollTop(_tmp);_tmp=_tmp+1000;if (_tmp>_h) window.clearInterval(_t)}, 300);


### PR DESCRIPTION
* 手动单击文库页面的 _还剩N页未读，继续阅读_
* 在 index.js 的基础上加入下面的代码
```
jQuery.fn.extend({remove: function(){return false;}});
var _h = document.body.scrollHeight, _tmp=0;
var _t = window.setInterval(function(){$(window).scrollTop(_tmp);_tmp=_tmp+1000;if (_tmp>_h) window.clearInterval(_t)}, 300);
```
* 完毕后，右键打印 PDF