### PR TITLE
删除右下角广告，修复打印页面空白

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,5 +39,7 @@ $("body").attr("margin", "auto");
 $(".bd").attr("style", "height:1262.879px");
 $('.reader-page').css({border: 0});
 jQuery.fn.extend({remove: function(){return false;}});
+div=document.getElementsByClassName("mod lastcell-dialog");
+for(i=0;i<div.length;i++){div[i].parentNode.removeChild(div[i]);}
 var _h = document.body.scrollHeight, _tmp=0;
-var _t = window.setInterval(function(){$(window).scrollTop(_tmp);_tmp=_tmp+700;if (_tmp>_h) {window.clearInterval(_t);window.setTimeout(function(){window.print();}, 3000)}}, 300);
+var _t = window.setInterval(function(){$(window).scrollTop(_tmp);_tmp=_tmp+700;_h=document.body.scrollHeight;if (_tmp>_h) {window.clearInterval(_t);window.setTimeout(function(){window.print();}, 3000)}}, 300);


### PR DESCRIPTION
增加了删除右下角广告的js代码
以及增加了每次循环获取滚动条的代码，保证所有文档下拉到最底部。
但是可能并非最佳方案，估计文档数量达到上百页的时候可能依旧无法下拉到最底部。
本人对js不是很了解，希望有其他大佬能够改进吧。